### PR TITLE
Allows for blank command.

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -4,6 +4,11 @@
 RegisterCommand("setspikes", function(source, args, raw)
     local src = source
 
+	if(args[1] == nil) then
+		print('Is blank!')
+		args[1] = 2
+	end
+        
     if tonumber(args[1]) <= SpikeConfig.MaxSpikes then
         SpawnSpikestrips(src, args[1])
     end

--- a/server.lua
+++ b/server.lua
@@ -5,7 +5,6 @@ RegisterCommand("setspikes", function(source, args, raw)
     local src = source
 
 	if(args[1] == nil) then
-		print('Is blank!')
 		args[1] = 2
 	end
         


### PR DESCRIPTION
Allows for users to type the command with arguments. Defaults to 2 spikes.